### PR TITLE
Stargate usdc strategy

### DIFF
--- a/src/Swap.sol
+++ b/src/Swap.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.9;
 
+import 'forge-std/console.sol';
+
 import 'solmate/tokens/ERC20.sol';
 import 'solmate/utils/SafeTransferLib.sol';
 import './external/uniswap/ISwapRouter02.sol';
@@ -219,6 +221,8 @@ contract Swap is Ownable {
 		bytes memory _path
 	) internal returns (uint256) {
 		address[] memory path = abi.decode(_path, (address[]));
+
+		console.log('Here in swap!');
 
 		return uniswap.swapExactTokensForTokens(_amount, _minReceived, path, msg.sender);
 	}

--- a/src/Swap.sol
+++ b/src/Swap.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.9;
 
-import 'forge-std/console.sol';
-
 import 'solmate/tokens/ERC20.sol';
 import 'solmate/utils/SafeTransferLib.sol';
 import './external/uniswap/ISwapRouter02.sol';
@@ -221,8 +219,6 @@ contract Swap is Ownable {
 		bytes memory _path
 	) internal returns (uint256) {
 		address[] memory path = abi.decode(_path, (address[]));
-
-		console.log('Here in swap!');
 
 		return uniswap.swapExactTokensForTokens(_amount, _minReceived, path, msg.sender);
 	}

--- a/src/external/stargate/ILPStaking.sol
+++ b/src/external/stargate/ILPStaking.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+// basically a Goose MasterChef
+// https://etherscan.io/address/0xB0D502E938ed5f4df2E681fE6E419ff29631d62b#code
+
+interface ILPStaking {
+	function poolInfo(uint256 _pid)
+		external
+		view
+		returns (
+			address lpToken,
+			uint256 allocPoint,
+			uint256 lastRewardBlock,
+			uint256 accStargatePerShare
+		);
+
+	function userInfo(uint256 _pid, address _address) external view returns (uint256 amount, uint256 rewardDebt);
+
+	function deposit(uint256 _pid, uint256 _amount) external;
+
+	function withdraw(uint256 _pid, uint256 _amount) external;
+}

--- a/src/external/stargate/IPool.sol
+++ b/src/external/stargate/IPool.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.9;
+
+interface IPool {
+	function deltaCredit() external view returns (uint256);
+}

--- a/src/external/stargate/IStargateRouter.sol
+++ b/src/external/stargate/IStargateRouter.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+interface IStargateRouter {
+	struct lzTxObj {
+		uint256 dstGasForCall;
+		uint256 dstNativeAmount;
+		bytes dstNativeAddr;
+	}
+
+	function addLiquidity(
+		uint256 _poolId,
+		uint256 _amountLD,
+		address _to
+	) external;
+
+	function instantRedeemLocal(
+		uint256 _srcPoolId,
+		uint256 _amountLP,
+		address _to
+	) external returns (uint256);
+
+	function redeemLocal(
+		uint256 _dstChainId,
+		uint256 _srcPoolId,
+		uint256 _dstPoolId,
+		address payable _refundAddress,
+		uint256 _amountLP,
+		bytes calldata _to,
+		lzTxObj memory _lzTxParams
+	) external payable;
+}

--- a/src/external/stargate/IStargateRouter.sol
+++ b/src/external/stargate/IStargateRouter.sol
@@ -15,7 +15,7 @@ interface IStargateRouter {
 	) external;
 
 	function instantRedeemLocal(
-		uint256 _srcPoolId,
+		uint16 _srcPoolId,
 		uint256 _amountLP,
 		address _to
 	) external returns (uint256);

--- a/src/external/stargate/IStargateRouter.sol
+++ b/src/external/stargate/IStargateRouter.sol
@@ -21,7 +21,7 @@ interface IStargateRouter {
 	) external returns (uint256);
 
 	function redeemLocal(
-		uint256 _dstChainId,
+		uint16 _dstChainId,
 		uint256 _srcPoolId,
 		uint256 _dstPoolId,
 		address payable _refundAddress,
@@ -29,4 +29,14 @@ interface IStargateRouter {
 		bytes calldata _to,
 		lzTxObj memory _lzTxParams
 	) external payable;
+
+	function callDelta(uint256 _poolId, bool _fullMode) external;
+
+	function quoteLayerZeroFee(
+		uint16 _dstChainId,
+		uint8 _functionType,
+		bytes calldata _toAddress,
+		bytes calldata _transferAndCallPayload,
+		lzTxObj memory _lzTxParams
+	) external view returns (uint256, uint256);
 }

--- a/src/strategies/StrategyStargate.sol
+++ b/src/strategies/StrategyStargate.sol
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.9;
+
+import 'forge-std/console.sol';
+
+import '../external/stargate/IStargateRouter.sol';
+import '../external/stargate/ILPStaking.sol';
+import '../Swap.sol';
+import '../Strategy.sol';
+
+abstract contract StrategyStargate is Strategy {
+	using SafeTransferLib for ERC20;
+	using FixedPointMathLib for uint256;
+
+	IStargateRouter internal constant router = IStargateRouter(0x8731d54E9D02c286767d56ac03e8037C07e01e98);
+	ILPStaking internal constant staking = ILPStaking(0xB0D502E938ed5f4df2E681fE6E419ff29631d62b);
+	ERC20 internal constant STG = ERC20(0xAf5191B0De278C7286d6C7CC6ab6BB8A73bA2Cd6);
+
+	/// @dev pid of asset in their router
+	uint256 public immutable routerPoolId;
+	/// @dev pid of asset in their LP staking contract
+	uint256 public immutable stakingPoolId;
+	ERC20 public immutable lpToken;
+
+	/// @notice contract used to swap STG rewards to USDC
+	Swap public swap;
+
+	/*///////////////
+	/     Errors    /
+	///////////////*/
+
+	error NoRewards();
+	error NothingToInvest();
+
+	constructor(
+		Vault _vault,
+		address _treasury,
+		address[] memory _authorized,
+		Swap _swap,
+		uint256 _routerPoolId,
+		uint256 _stakingPoolId
+	) Strategy(_vault, _treasury, _authorized) {
+		swap = _swap;
+		routerPoolId = _routerPoolId;
+		stakingPoolId = _stakingPoolId;
+		(address lpTokenAddress, , , ) = staking.poolInfo(stakingPoolId);
+		lpToken = ERC20(lpTokenAddress);
+
+		_approve();
+	}
+
+	/*///////////////////////
+	/      Public View      /
+	///////////////////////*/
+
+	function totalAssets() public view override returns (uint256 assets) {
+		(uint256 stakedBalance, ) = staking.userInfo(stakingPoolId, address(this));
+		return stakedBalance;
+	}
+
+	/*///////////////////////////////////////////
+	/      Restricted Functions: onlyOwner      /
+	///////////////////////////////////////////*/
+
+	function changeSwap(Swap _swap) external onlyOwner {
+		_unapproveSwap();
+		swap = _swap;
+		_approveSwap();
+	}
+
+	/*////////////////////////////////////////////////
+	/      Restricted Functions: onlyAuthorized      /
+	////////////////////////////////////////////////*/
+
+	function reapprove() external onlyAuthorized {
+		_unapprove();
+		_approve();
+	}
+
+	/*/////////////////////////////
+	/      Internal Override      /
+	/////////////////////////////*/
+
+	function _withdraw(uint256 _assets, address _receiver) internal override returns (uint256 received) {
+		uint256 assets = totalAssets();
+		if (assets == 0) return 0; // nothing to withdraw;
+
+		uint256 amount = _assets > assets ? assets : _assets;
+
+		// 1. withdraw from staking contract
+		staking.withdraw(stakingPoolId, amount);
+
+		console.log('Here!');
+		console.log(amount, lpToken.balanceOf(address(this)));
+
+		// withdraw from stargate router
+		received = router.instantRedeemLocal(routerPoolId, amount, _receiver);
+	}
+
+	function _harvest() internal override {
+		// empty deposit claims rewards withdraw as with all Goose clones
+		staking.deposit(stakingPoolId, 0);
+
+		uint256 rewardBalance = STG.balanceOf(address(this));
+		if (rewardBalance == 0) revert NoRewards(); // nothing to harvest
+
+		swap.swapTokens(address(STG), address(asset), rewardBalance, 1);
+
+		asset.safeTransfer(address(vault), asset.balanceOf(address(this)));
+	}
+
+	function _invest() internal override {
+		uint256 assetBalance = asset.balanceOf(address(this));
+		if (assetBalance == 0) revert NothingToInvest();
+
+		router.addLiquidity(routerPoolId, assetBalance, address(this));
+
+		uint256 balance = lpToken.balanceOf(address(this));
+
+		staking.deposit(stakingPoolId, balance);
+	}
+
+	/*//////////////////////////////
+	/      Internal Functions      /
+	//////////////////////////////*/
+
+	function _approve() internal {
+		// approve deposit asset into router
+		asset.safeApprove(address(router), type(uint256).max);
+		// approve deposit lpToken into staking contract
+		lpToken.safeApprove(address(staking), type(uint256).max);
+
+		_approveSwap();
+	}
+
+	function _unapprove() internal {
+		asset.safeApprove(address(router), 0);
+		lpToken.safeApprove(address(staking), 0);
+
+		_unapproveSwap();
+	}
+
+	// approve swap rewards to USDC
+	function _unapproveSwap() internal {
+		STG.safeApprove(address(swap), 0);
+	}
+
+	// approve swap rewards to USDC
+	function _approveSwap() internal {
+		STG.safeApprove(address(swap), type(uint256).max);
+	}
+}

--- a/src/strategies/StrategyStargate.sol
+++ b/src/strategies/StrategyStargate.sol
@@ -20,7 +20,7 @@ abstract contract StrategyStargate is Strategy {
 	uint256 public immutable stakingPoolId;
 	ERC20 public immutable lpToken;
 
-	/// @notice contract used to swap STG rewards to USDC
+	/// @notice contract used to swap STG rewards to asset
 	Swap public swap;
 
 	/*///////////////
@@ -141,12 +141,12 @@ abstract contract StrategyStargate is Strategy {
 		_unapproveSwap();
 	}
 
-	// approve swap rewards to USDC
+	// approve swap rewards to asset
 	function _unapproveSwap() internal {
 		STG.safeApprove(address(swap), 0);
 	}
 
-	// approve swap rewards to USDC
+	// approve swap rewards to asset
 	function _approveSwap() internal {
 		STG.safeApprove(address(swap), type(uint256).max);
 	}

--- a/src/strategies/UsdcStrategyStargate.sol
+++ b/src/strategies/UsdcStrategyStargate.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.9;
+
+import './StrategyStargate.sol';
+
+contract UsdcStrategyStargate is StrategyStargate {
+	constructor(
+		Vault _vault,
+		address _treasury,
+		address[] memory _authorized,
+		Swap _swap
+	) StrategyStargate(_vault, _treasury, _authorized, _swap, 1, 0) {}
+}

--- a/test/integration/UsdcStrategyStargate.t.sol
+++ b/test/integration/UsdcStrategyStargate.t.sol
@@ -37,7 +37,7 @@ contract UsdcStrategyStargateTest is Test, TestHelpers {
 		swap.setRoute(
 			address(STG),
 			address(USDC),
-			Swap.RouteInfo({route: Swap.Route.UniswapV2, info: abi.encode(path)})
+			Swap.RouteInfo({route: Swap.Route.UniswapV3Direct, info: abi.encode(uint24(3_000))})
 		);
 
 		strategy = new UsdcStrategyStargate(vault, treasury, new address[](0), swap);

--- a/test/integration/UsdcStrategyStargate.t.sol
+++ b/test/integration/UsdcStrategyStargate.t.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+import 'forge-std/Test.sol';
+import 'solmate/tokens/ERC20.sol';
+import 'src/Vault.sol';
+import 'src/strategies/UsdcStrategyStargate.sol';
+import 'src/Swap.sol';
+import '../TestHelpers.sol';
+
+contract UsdcStrategyStargateTest is Test, TestHelpers {
+	Vault vault;
+	Swap swap;
+	Strategy strategy;
+
+	address constant u1 = address(0xABCD);
+	address constant treasury = address(0xAAAF);
+
+	ERC20 constant USDC = ERC20(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
+	address constant usdcWhale = 0x55FE002aefF02F77364de339a1292923A15844B8;
+
+	// 1 USDC
+	uint256 internal constant lowerLimit = 1e6;
+	uint256 internal constant upperLimit = 1e12;
+
+	ERC20 constant STG = ERC20(0xAf5191B0De278C7286d6C7CC6ab6BB8A73bA2Cd6);
+
+	function setUp() public {
+		vault = new Vault(USDC, new address[](0), 0);
+		swap = new Swap();
+
+		address[] memory path = new address[](3);
+		path[0] = address(STG);
+		path[1] = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2; // WETH
+		path[2] = address(USDC);
+
+		swap.setRoute(
+			address(STG),
+			address(USDC),
+			Swap.RouteInfo({route: Swap.Route.UniswapV2, info: abi.encode(path)})
+		);
+
+		strategy = new UsdcStrategyStargate(vault, treasury, new address[](0), swap);
+		vault.addStrategy(strategy, 100);
+	}
+
+	/*///////////////////
+	/      Helpers      /
+	///////////////////*/
+
+	function depositUsdc(
+		address from,
+		uint256 amount,
+		address receiver
+	) public {
+		vm.prank(usdcWhale);
+		USDC.transfer(from, amount);
+		vm.startPrank(from);
+		USDC.approve(address(vault), type(uint256).max);
+		vault.deposit(amount, receiver);
+		vm.stopPrank();
+	}
+
+	/*/////////////////
+	/      Tests      /
+	/////////////////*/
+
+	function testDepositAndInvest(uint256 amount) public {
+		vm.assume(amount >= lowerLimit && amount <= upperLimit);
+
+		depositUsdc(u1, amount, u1);
+
+		assertEq(vault.totalAssets(), amount);
+
+		vault.report(strategy);
+		assertCloseTo(strategy.totalAssets(), amount, 1); // 0.1%
+	}
+
+	function testWithdraw(uint256 amount) public {
+		vm.assume(amount >= lowerLimit && amount <= upperLimit);
+
+		depositUsdc(u1, amount, u1);
+
+		vault.report(strategy);
+
+		vm.startPrank(u1);
+		vault.redeem(vault.balanceOf(u1), u1, u1);
+
+		assertCloseTo(USDC.balanceOf(u1), amount, 1); // 0.1%
+	}
+
+	function testHarvest(uint256 amount) public {
+		vm.assume(amount >= lowerLimit && amount <= upperLimit);
+
+		depositUsdc(u1, amount, u1);
+
+		vault.report(strategy);
+
+		uint256 startingAssets = strategy.totalAssets();
+
+		assertEq(STG.balanceOf(treasury), 0);
+
+		vm.roll(block.number + 300_000);
+
+		vault.harvest(strategy);
+
+		assertGt(strategy.totalAssets(), startingAssets);
+		assertGt(STG.balanceOf(treasury), 0);
+	}
+}

--- a/test/integration/UsdcStrategyStargate.t.sol
+++ b/test/integration/UsdcStrategyStargate.t.sol
@@ -21,18 +21,14 @@ contract UsdcStrategyStargateTest is Test, TestHelpers {
 
 	// 1 USDC
 	uint256 internal constant lowerLimit = 1e6;
-	uint256 internal constant upperLimit = 1e12;
+	// 10 million USDC
+	uint256 internal constant upperLimit = 10e12;
 
 	ERC20 constant STG = ERC20(0xAf5191B0De278C7286d6C7CC6ab6BB8A73bA2Cd6);
 
 	function setUp() public {
 		vault = new Vault(USDC, new address[](0), 0);
 		swap = new Swap();
-
-		address[] memory path = new address[](3);
-		path[0] = address(STG);
-		path[1] = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2; // WETH
-		path[2] = address(USDC);
 
 		swap.setRoute(
 			address(STG),


### PR DESCRIPTION
Stargate's redeem function seems to stop working past ~10 million USDC. Doesn't throw an error, only redeem 3 USDC (always 3, whether we withdraw 20 million or 100 million). 

so weird. doesn't seem to be a safety feature or time-weighted average limit either. setting a min on withdraw catches this but might be indicative of some issue in their code. not sure if need to look more into it