### PR TITLE
fix locked profit and update events

### DIFF
--- a/src/Strategy.sol
+++ b/src/Strategy.sol
@@ -80,8 +80,8 @@ abstract contract Strategy is Ownership {
 		}
 	}
 
-	function harvest() external onlyVault {
-		_harvest();
+	function harvest() external onlyVault returns (uint256 assets) {
+		return _harvest();
 	}
 
 	function invest() external onlyVault {
@@ -120,6 +120,10 @@ abstract contract Strategy is Ownership {
 		_harvest();
 	}
 
+	function adminInvest() external onlyAdmins {
+		_invest();
+	}
+
 	/*////////////////////////////
 	/      Internal Virtual      /
 	////////////////////////////*/
@@ -127,7 +131,8 @@ abstract contract Strategy is Ownership {
 	/// @dev this must handle overflow, i.e. vault trying to withdraw more than what strategy has
 	function _withdraw(uint256 _assets, address _receiver) internal virtual returns (uint256 received);
 
-	function _harvest() internal virtual;
+	/// @dev return harvested assets
+	function _harvest() internal virtual returns (uint256 received);
 
 	function _invest() internal virtual;
 

--- a/src/Vault.sol
+++ b/src/Vault.sol
@@ -51,7 +51,7 @@ contract Vault is ERC20, IERC4626, Ownership, BlockDelay {
 
 	event Report(Strategy indexed strategy, uint256 harvested, uint256 gain, uint256 loss);
 	event Lend(Strategy indexed strategy, uint256 assets, uint256 slippage);
-	event Collect(Strategy indexed strategy, address indexed receiver, uint256 received, uint256 slippage);
+	event Collect(Strategy indexed strategy, uint256 received, uint256 slippage);
 
 	event StrategyAdded(Strategy indexed strategy, uint256 debtRatio);
 	event StrategyDebtRatioChanged(Strategy indexed strategy, uint256 newDebtRatio);
@@ -508,7 +508,7 @@ contract Vault is ERC20, IERC4626, Ownership, BlockDelay {
 		strategies[_strategy].debt -= amount;
 		totalDebt -= amount;
 
-		emit Collect(_strategy, _receiver, received, slippage);
+		if (_receiver == address(this)) emit Collect(_strategy, received, slippage);
 	}
 
 	function _harvest(Strategy _strategy) internal {

--- a/src/Vault.sol
+++ b/src/Vault.sol
@@ -49,7 +49,9 @@ contract Vault is ERC20, IERC4626, Ownership, BlockDelay {
 	/      Events      /
 	//////////////////*/
 
-	event Report(Strategy indexed strategy, uint256 gain, uint256 loss);
+	event Report(Strategy indexed strategy, uint256 harvested, uint256 gain, uint256 loss);
+	event Lend(Strategy indexed strategy, uint256 assets, uint256 slippage);
+	event Collect(Strategy indexed strategy, address indexed receiver, uint256 received, uint256 slippage);
 
 	event StrategyAdded(Strategy indexed strategy, uint256 debtRatio);
 	event StrategyDebtRatioChanged(Strategy indexed strategy, uint256 newDebtRatio);
@@ -364,9 +366,7 @@ contract Vault is ERC20, IERC4626, Ownership, BlockDelay {
 	function harvestAll() external onlyAuthorized updateLastReport {
 		uint8 length = uint8(_queue.length);
 		for (uint8 i = 0; i < length; ++i) {
-			Strategy strategy = _queue[i];
-			strategy.harvest();
-			_report(strategy);
+			_harvest(_queue[i]);
 		}
 	}
 
@@ -374,21 +374,20 @@ contract Vault is ERC20, IERC4626, Ownership, BlockDelay {
 	function reportAll() external onlyAuthorized updateLastReport {
 		uint8 length = uint8(_queue.length);
 		for (uint8 i = 0; i < length; ++i) {
-			_report(_queue[i]);
+			_report(_queue[i], 0);
 		}
 	}
 
 	function harvest(Strategy _strategy) external onlyAuthorized updateLastReport {
 		if (!strategies[_strategy].added) revert NotStrategy();
 
-		_strategy.harvest();
-		_report(_strategy);
+		_harvest(_strategy);
 	}
 
 	function report(Strategy _strategy) external onlyAuthorized updateLastReport {
 		if (!strategies[_strategy].added) revert NotStrategy();
 
-		_report(_strategy);
+		_report(_strategy, 0);
 	}
 
 	/*///////////////////////////////////////////
@@ -484,8 +483,14 @@ contract Vault is ERC20, IERC4626, Ownership, BlockDelay {
 		asset.safeTransfer(address(_strategy), amount);
 		_strategy.invest();
 
-		strategies[_strategy].debt += amount;
-		totalDebt += amount;
+		uint256 debtBefore = strategies[_strategy].debt;
+		uint256 debtAfter = _strategy.totalAssets();
+
+		uint256 slippage = debtBefore > debtAfter ? debtBefore - debtAfter : 0;
+
+		totalDebt += amount - slippage;
+
+		emit Lend(_strategy, amount, slippage);
 	}
 
 	/// @dev overflow is handled by strategy
@@ -502,9 +507,15 @@ contract Vault is ERC20, IERC4626, Ownership, BlockDelay {
 
 		strategies[_strategy].debt -= amount;
 		totalDebt -= amount;
+
+		emit Collect(_strategy, _receiver, received, slippage);
 	}
 
-	function _report(Strategy _strategy) internal {
+	function _harvest(Strategy _strategy) internal {
+		_report(_strategy, _strategy.harvest());
+	}
+
+	function _report(Strategy _strategy, uint256 _harvested) internal {
 		uint256 assets = _strategy.totalAssets();
 		uint256 debt = strategies[_strategy].debt;
 
@@ -513,20 +524,21 @@ contract Vault is ERC20, IERC4626, Ownership, BlockDelay {
 		uint256 gain;
 		uint256 loss;
 
+		uint256 lockedProfitBefore = lockedProfit();
+
 		if (assets > debt) {
 			unchecked {
 				gain = assets - debt;
 			}
 			totalDebt += gain;
 
-			_lockedProfit = lockedProfit() + gain;
+			_lockedProfit = lockedProfitBefore + gain + _harvested;
 		} else if (debt > assets) {
 			unchecked {
 				loss = debt - assets;
 				totalDebt -= loss;
 
-				uint256 lockedProfitBeforeLoss = lockedProfit();
-				_lockedProfit = lockedProfitBeforeLoss > loss ? lockedProfitBeforeLoss - loss : 0;
+				_lockedProfit = lockedProfitBefore + _harvested > loss ? lockedProfitBefore + _harvested - loss : 0;
 			}
 		}
 
@@ -537,7 +549,7 @@ contract Vault is ERC20, IERC4626, Ownership, BlockDelay {
 		if (possibleDebt > assets) _lend(_strategy, possibleDebt - assets);
 		else if (assets > possibleDebt) _collect(_strategy, assets - possibleDebt, address(this));
 
-		emit Report(_strategy, gain, loss);
+		emit Report(_strategy, _harvested, gain, loss);
 	}
 
 	function _setDebtRatio(Strategy _strategy, uint256 _newDebtRatio) internal {

--- a/src/strategies/StrategyCompound.sol
+++ b/src/strategies/StrategyCompound.sol
@@ -146,7 +146,7 @@ abstract contract StrategyCompound is Strategy {
 		asset.safeTransfer(_receiver, amount);
 	}
 
-	function _harvest() internal override {
+	function _harvest() internal override returns (uint256 received) {
 		address[] memory cTokens = new address[](1);
 		cTokens[0] = address(cToken);
 		comptroller.claimComp(address(this), cTokens);
@@ -161,7 +161,9 @@ abstract contract StrategyCompound is Strategy {
 		}
 
 		swap.swapTokens(address(COMP), address(asset), compBal, 1);
-		asset.safeTransfer(address(vault), asset.balanceOf(address(this)));
+
+		received = asset.balanceOf(address(this));
+		asset.safeTransfer(address(vault), received);
 	}
 
 	function _invest() internal override {

--- a/src/strategies/StrategyStargate.sol
+++ b/src/strategies/StrategyStargate.sol
@@ -23,14 +23,6 @@ abstract contract StrategyStargate is Strategy {
 	/// @notice contract used to swap STG rewards to asset
 	Swap public swap;
 
-	/*//////////////////
-	/      Events      /
-	//////////////////*/
-
-	event Withdrawal(uint256 assets, uint256 received, address receiver);
-	event Harvest(uint256 assets);
-	event Invest(uint256 assets, uint256 assetsAfter);
-
 	/*///////////////
 	/     Errors    /
 	///////////////*/
@@ -138,11 +130,9 @@ abstract contract StrategyStargate is Strategy {
 		received = router.instantRedeemLocal(routerPoolId, lpAmount, _receiver);
 
 		if (received < _calculateSlippage(amount)) revert BelowMinimum(received);
-
-		emit Withdrawal(amount, received, _receiver);
 	}
 
-	function _harvest() internal override {
+	function _harvest() internal override returns (uint256 received) {
 		// empty deposit/withdraw claims rewards withdraw as with all Goose clones
 		staking.withdraw(stakingPoolId, 0);
 
@@ -157,11 +147,8 @@ abstract contract StrategyStargate is Strategy {
 
 		swap.swapTokens(address(STG), address(asset), rewardBalance, 1);
 
-		uint256 received = asset.balanceOf(address(this));
-
+		received = asset.balanceOf(address(this));
 		asset.safeTransfer(address(vault), received);
-
-		emit Harvest(received);
 	}
 
 	function _invest() internal override {
@@ -175,8 +162,6 @@ abstract contract StrategyStargate is Strategy {
 		if (balance < _calculateSlippage(assetBalance)) revert BelowMinimum(balance);
 
 		staking.deposit(stakingPoolId, balance);
-
-		emit Invest(assetBalance, balance);
 	}
 
 	/*//////////////////////////////

--- a/src/strategies/UsdcStrategyConvex.sol
+++ b/src/strategies/UsdcStrategyConvex.sol
@@ -122,7 +122,7 @@ contract UsdcStrategyConvex is Strategy {
 			);
 	}
 
-	function _harvest() internal override {
+	function _harvest() internal override returns (uint256 received) {
 		if (!reward.getReward(address(this), shouldClaimExtras)) revert ClaimRewardsFailed();
 
 		uint8 length = uint8(rewards.length);
@@ -142,7 +142,8 @@ contract UsdcStrategyConvex is Strategy {
 			swap.swapTokens(address(rewardToken), address(asset), rewardBalance, 1);
 		}
 
-		asset.safeTransfer(address(vault), asset.balanceOf(address(this)));
+		received = asset.balanceOf(address(this));
+		asset.safeTransfer(address(vault), received);
 	}
 
 	function _invest() internal override {

--- a/src/strategies/UsdcStrategyConvexGen2.sol
+++ b/src/strategies/UsdcStrategyConvexGen2.sol
@@ -124,7 +124,7 @@ contract UsdcStrategyConvexGen2 is Strategy {
 		asset.safeTransfer(_receiver, received);
 	}
 
-	function _harvest() internal override {
+	function _harvest() internal override returns (uint256 received) {
 		if (!reward.getReward(address(this), shouldClaimExtras)) revert ClaimRewardsFailed();
 
 		uint8 length = uint8(rewards.length);
@@ -144,7 +144,8 @@ contract UsdcStrategyConvexGen2 is Strategy {
 			swap.swapTokens(address(rewardToken), address(asset), rewardBalance, 1);
 		}
 
-		asset.safeTransfer(address(vault), asset.balanceOf(address(this)));
+		received = asset.balanceOf(address(this));
+		asset.safeTransfer(address(vault), received);
 	}
 
 	function _invest() internal override {

--- a/src/strategies/WbtcStrategyConvexGen2.sol
+++ b/src/strategies/WbtcStrategyConvexGen2.sol
@@ -124,7 +124,7 @@ contract WbtcStrategyConvexGen2 is Strategy {
 		asset.safeTransfer(_receiver, received);
 	}
 
-	function _harvest() internal override {
+	function _harvest() internal override returns (uint256 received) {
 		if (!reward.getReward(address(this), shouldClaimExtras)) revert ClaimRewardsFailed();
 
 		uint8 length = uint8(rewards.length);
@@ -144,7 +144,8 @@ contract WbtcStrategyConvexGen2 is Strategy {
 			swap.swapTokens(address(rewardToken), address(asset), rewardBalance, 1);
 		}
 
-		asset.safeTransfer(address(vault), asset.balanceOf(address(this)));
+		received = asset.balanceOf(address(this));
+		asset.safeTransfer(address(vault), received);
 	}
 
 	function _invest() internal override {

--- a/src/strategies/WbtcStrategyConvexPbtc.sol
+++ b/src/strategies/WbtcStrategyConvexPbtc.sol
@@ -115,7 +115,7 @@ contract WbtcStrategyConvexPbtc is Strategy {
 		asset.safeTransfer(_receiver, received);
 	}
 
-	function _harvest() internal override {
+	function _harvest() internal override returns (uint256 received) {
 		if (!reward.getReward(address(this), shouldClaimExtras)) revert ClaimRewardsFailed();
 
 		uint8 length = uint8(rewards.length);
@@ -135,7 +135,8 @@ contract WbtcStrategyConvexPbtc is Strategy {
 			swap.swapTokens(address(rewardToken), address(asset), rewardBalance, 1);
 		}
 
-		asset.safeTransfer(address(vault), asset.balanceOf(address(this)));
+		received = asset.balanceOf(address(this));
+		asset.safeTransfer(address(vault), received);
 	}
 
 	function _invest() internal override {

--- a/src/strategies/WbtcStrategyConvexRen.sol
+++ b/src/strategies/WbtcStrategyConvexRen.sol
@@ -111,7 +111,7 @@ contract WbtcStrategyConvexRen is Strategy {
 		asset.safeTransfer(_receiver, received);
 	}
 
-	function _harvest() internal override {
+	function _harvest() internal override returns (uint256 received) {
 		if (!reward.getReward(address(this), shouldClaimExtras)) revert ClaimRewardsFailed();
 
 		uint8 length = uint8(rewards.length);
@@ -131,7 +131,8 @@ contract WbtcStrategyConvexRen is Strategy {
 			swap.swapTokens(address(rewardToken), address(asset), rewardBalance, 1);
 		}
 
-		asset.safeTransfer(address(vault), asset.balanceOf(address(this)));
+		received = asset.balanceOf(address(this));
+		asset.safeTransfer(address(vault), received);
 	}
 
 	function _invest() internal override {

--- a/src/strategies/WethStrategyConvexStEth.sol
+++ b/src/strategies/WethStrategyConvexStEth.sol
@@ -34,14 +34,6 @@ contract WethStrategyConvexStEth is Strategy {
 	/// @dev offset pool.get_virtual_price()'s 18 decimals
 	uint256 internal constant NORMALIZED_DECIMAL_OFFSET = 1e18;
 
-	/*//////////////////
-	/      Events      /
-	//////////////////*/
-
-	event Withdrawal(uint256 assets, uint256 received, address receiver);
-	event Harvest(uint256 assets);
-	event Invest(uint256 assets, uint256 assetsAfter);
-
 	/*///////////////
 	/     Errors    /
 	///////////////*/
@@ -123,11 +115,9 @@ contract WethStrategyConvexStEth is Strategy {
 		WETH(payable(address(asset))).deposit{value: received}();
 
 		asset.safeTransfer(_receiver, received);
-
-		emit Withdrawal(amount, received, _receiver);
 	}
 
-	function _harvest() internal override {
+	function _harvest() internal override returns (uint256 received) {
 		if (!reward.getReward(address(this), shouldClaimExtras)) revert ClaimRewardsFailed();
 
 		uint8 length = uint8(rewards.length);
@@ -147,11 +137,8 @@ contract WethStrategyConvexStEth is Strategy {
 			swap.swapTokens(address(rewardToken), address(asset), rewardBalance, 1);
 		}
 
-		uint256 received = asset.balanceOf(address(this));
-
+		received = asset.balanceOf(address(this));
 		asset.safeTransfer(address(vault), received);
-
-		emit Harvest(received);
 	}
 
 	function _invest() internal override {
@@ -168,9 +155,6 @@ contract WethStrategyConvexStEth is Strategy {
 
 		uint256 poolTokens = poolToken.balanceOf(address(this));
 		if (!booster.deposit(pid, poolTokens, true)) revert DepositFailed();
-
-		uint256 assetsAfter = poolTokens.mulDivDown(virtualPrice, NORMALIZED_DECIMAL_OFFSET);
-		emit Invest(assetBalance, assetsAfter);
 	}
 
 	/*//////////////////////////////


### PR DESCRIPTION
- Fix `lockedProfit` not taking into account harvested rewards

- Move events from Strategy level to Vault level to make calculating ROI, slippage, etc. easier and reduce boilerplate for future strategies