### PR TITLE
handle edge case if withdrawn amount > intended amount

### DIFF
--- a/src/strategies/StrategyStargate.sol
+++ b/src/strategies/StrategyStargate.sol
@@ -113,14 +113,14 @@ abstract contract StrategyStargate is Strategy {
 	/      Internal Override      /
 	/////////////////////////////*/
 
-	function _withdraw(uint256 _assets, address _receiver) internal override returns (uint256 received) {
+	function _withdraw(uint256 _assets) internal override returns (uint256 received) {
 		uint256 lpAmount = convertAssetToLP(_assets);
 
 		// 1. withdraw from staking contract
 		staking.withdraw(stakingPoolId, lpAmount);
 
 		// withdraw from stargate router
-		received = router.instantRedeemLocal(routerPoolId, lpAmount, _receiver);
+		received = router.instantRedeemLocal(routerPoolId, lpAmount, address(vault));
 
 		if (received < _calculateSlippage(_assets)) revert BelowMinimum(received);
 	}

--- a/src/strategies/WethStrategyConvexStEth.sol
+++ b/src/strategies/WethStrategyConvexStEth.sol
@@ -95,7 +95,7 @@ contract WethStrategyConvexStEth is Strategy {
 	/      Internal Override      /
 	/////////////////////////////*/
 
-	function _withdraw(uint256 _assets, address _receiver) internal override returns (uint256 received) {
+	function _withdraw(uint256 _assets) internal override returns (uint256 received) {
 		uint256 tokenAmount = _assets.mulDivDown(reward.balanceOf(address(this)), totalAssets());
 
 		if (!reward.withdrawAndUnwrap(tokenAmount, true)) revert WithdrawAndUnwrapFailed();
@@ -109,7 +109,7 @@ contract WethStrategyConvexStEth is Strategy {
 
 		WETH(payable(address(asset))).deposit{value: received}();
 
-		asset.safeTransfer(_receiver, received);
+		asset.safeTransfer(address(vault), received);
 	}
 
 	function _harvest() internal override returns (uint256 received) {


### PR DESCRIPTION
- Handle edge case if e.g. withdraw 100 but received 101, which might happen with certain LP-based strategies
- Bonuses aren't passed to user to prevents users from draining vaults