### PR TITLE
balancer batch swap

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.9;
 
 import 'forge-std/console.sol';
-
 import 'forge-std/Script.sol';
+
 import 'src/strategies/UsdcStrategyStargate.sol';
 import 'src/strategies/WethStrategyConvexStEth.sol';
 import 'src/zaps/WethZap.sol';

--- a/script/Swap.s.sol
+++ b/script/Swap.s.sol
@@ -5,6 +5,18 @@ import 'forge-std/console.sol';
 import 'forge-std/Script.sol';
 import 'src/Swap.sol';
 
+contract Deploy is Script {
+	function run() external {
+		vm.startBroadcast(vm.envUint('PRIVATE_KEY'));
+
+		Swap swap = new Swap();
+
+		console.log(address(swap));
+
+		vm.stopBroadcast();
+	}
+}
+
 contract GetRoute is Script {
 	using Path for bytes;
 
@@ -40,6 +52,23 @@ contract GetRoute is Script {
 
 			(, address tokenOut, ) = path.decodeFirstPool();
 			console.log(tokenOut);
+		} else if (data.route == Swap.Route.BalancerBatch) {
+			(IVault.BatchSwapStep[] memory steps, IAsset[] memory assets) = abi.decode(
+				data.info,
+				(IVault.BatchSwapStep[], IAsset[])
+			);
+
+			console.log('Pools:');
+
+			for (uint8 i = 0; i < steps.length; i++) {
+				console.log(string(abi.encodePacked(steps[i].poolId)));
+			}
+
+			console.log('Assets:');
+
+			for (uint8 i = 0; i < assets.length; i++) {
+				console.log(address(assets[i]));
+			}
 		} else {
 			console.log('Unsupported');
 		}

--- a/src/Swap.sol
+++ b/src/Swap.sol
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.9;
 
+import 'forge-std/console.sol';
+
 import 'solmate/tokens/ERC20.sol';
 import 'solmate/utils/SafeTransferLib.sol';
 import './external/uniswap/ISwapRouter02.sol';
 import './external/sushiswap/ISushiRouter.sol';
+import {IAsset, IVault} from './external/balancer/IVault.sol';
 import './libraries/Ownable.sol';
 import './libraries/Path.sol';
 
@@ -23,7 +26,8 @@ contract Swap is Ownable {
 		UniswapV2,
 		UniswapV3Direct,
 		UniswapV3Path,
-		SushiSwap
+		SushiSwap,
+		BalancerBatch
 	}
 
 	/**
@@ -41,21 +45,10 @@ contract Swap is Ownable {
 	/// @dev single address which supports both uniswap v2 and v3 routes
 	ISwapRouter02 internal constant uniswap = ISwapRouter02(0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45);
 
+	IVault internal constant balancer = IVault(0xBA12222222228d8Ba445958a75a0704d566BF2C8);
+
 	/// @dev tokenIn => tokenOut => routeInfo
 	mapping(address => mapping(address => RouteInfo)) public routes;
-
-	address internal constant CRV = 0xD533a949740bb3306d119CC777fa900bA034cd52;
-	address internal constant CVX = 0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B;
-
-	address internal constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
-	address internal constant WBTC = 0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599;
-
-	address internal constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
-	address internal constant DAI = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
-	address internal constant USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
-
-	address internal constant LDO = 0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32;
-	address internal constant PNT = 0x89Ab32156e46F46D02ade3FEcbe5Fc4243B9AAeD;
 
 	/*//////////////////
 	/      Events      /
@@ -72,19 +65,21 @@ contract Swap is Ownable {
 	error InvalidRouteInfo();
 
 	constructor() Ownable() {
-		// Solidity arrays are dumb
-		address[] memory path = new address[](3);
-		path[0] = CRV;
-		path[1] = WETH;
-		path[2] = USDC;
+		address CRV = 0xD533a949740bb3306d119CC777fa900bA034cd52;
+		address CVX = 0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B;
+		address LDO = 0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32;
 
-		_setRoute(CRV, USDC, RouteInfo({route: Route.UniswapV2, info: abi.encode(path)}));
+		address WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
 
-		path[2] = WBTC;
-		_setRoute(CRV, WBTC, RouteInfo({route: Route.SushiSwap, info: abi.encode(path)}));
+		address STG = 0xAf5191B0De278C7286d6C7CC6ab6BB8A73bA2Cd6;
+		address USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+		address USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
 
 		_setRoute(CRV, WETH, RouteInfo({route: Route.UniswapV3Direct, info: abi.encode(uint24(3_000))}));
+		_setRoute(CVX, WETH, RouteInfo({route: Route.UniswapV3Direct, info: abi.encode(uint24(10_000))}));
+		_setRoute(LDO, WETH, RouteInfo({route: Route.UniswapV3Direct, info: abi.encode(uint24(3_000))}));
 
+		_setRoute(CRV, USDC, RouteInfo({route: Route.UniswapV3Direct, info: abi.encode(uint24(10_000))}));
 		_setRoute(
 			CVX,
 			USDC,
@@ -93,29 +88,45 @@ contract Swap is Ownable {
 				info: abi.encodePacked(CVX, uint24(10_000), WETH, uint24(500), USDC)
 			})
 		);
-		_setRoute(
-			CVX,
-			WBTC,
-			RouteInfo({
-				route: Route.UniswapV3Path,
-				info: abi.encodePacked(CVX, uint24(10_000), WETH, uint24(500), WBTC)
-			})
-		);
 
-		address[] memory shortPath = new address[](2);
-		shortPath[0] = CVX;
-		shortPath[1] = WETH;
+		_setRoute(USDC, USDT, RouteInfo({route: Route.UniswapV3Direct, info: abi.encode(uint24(100))}));
 
-		_setRoute(CVX, WETH, RouteInfo({route: Route.SushiSwap, info: abi.encode(shortPath)}));
+		IAsset[] memory assets = new IAsset[](4);
+		assets[0] = IAsset(STG);
+		assets[1] = IAsset(0xA13a9247ea42D743238089903570127DdA72fE44); // bb-a-USD
+		assets[2] = IAsset(0x82698aeCc9E28e9Bb27608Bd52cF57f704BD1B83); // bb-a-USDC
+		assets[3] = IAsset(USDC);
 
-		shortPath[0] = LDO;
-		_setRoute(LDO, WETH, RouteInfo({route: Route.SushiSwap, info: abi.encode(shortPath)}));
+		IVault.BatchSwapStep[] memory steps = new IVault.BatchSwapStep[](3);
 
-		path[0] = PNT;
-		_setRoute(PNT, WBTC, RouteInfo({route: Route.UniswapV2, info: abi.encode(path)}));
+		// STG -> bb-a-USD
+		steps[0] = IVault.BatchSwapStep({
+			poolId: 0x4ce0bd7debf13434d3ae127430e9bd4291bfb61f00020000000000000000038b,
+			assetInIndex: 0,
+			assetOutIndex: 1,
+			amount: 0,
+			userData: ''
+		});
 
-		_setRoute(USDT, USDC, RouteInfo({route: Route.UniswapV3Direct, info: abi.encode(uint24(100))}));
-		_setRoute(DAI, USDC, RouteInfo({route: Route.UniswapV3Direct, info: abi.encode(uint24(100))}));
+		// bb-a-USD -> bb-a-USDC
+		steps[1] = IVault.BatchSwapStep({
+			poolId: 0xa13a9247ea42d743238089903570127dda72fe4400000000000000000000035d,
+			assetInIndex: 1,
+			assetOutIndex: 2,
+			amount: 0,
+			userData: ''
+		});
+
+		// bb-a-USDC -> USDC
+		steps[2] = IVault.BatchSwapStep({
+			poolId: 0x82698aecc9e28e9bb27608bd52cf57f704bd1b83000000000000000000000336,
+			assetInIndex: 2,
+			assetOutIndex: 3,
+			amount: 0,
+			userData: ''
+		});
+
+		_setRoute(STG, USDC, RouteInfo({route: Route.BalancerBatch, info: abi.encode(steps, assets)}));
 	}
 
 	/*///////////////////////
@@ -139,27 +150,34 @@ contract Swap is Ownable {
 		RouteInfo memory routeInfo = routes[_tokenIn][_tokenOut];
 		Route route = routeInfo.route;
 
-		ERC20(_tokenIn).safeTransferFrom(msg.sender, address(this), _amount);
+		ERC20 tokenIn = ERC20(_tokenIn);
+
+		tokenIn.safeTransferFrom(msg.sender, address(this), _amount);
 
 		bytes memory info = routeInfo.info;
 
-		if (route == Route.UniswapV2) return _uniswapV2(_amount, _minReceived, info);
-		if (route == Route.UniswapV3Direct) return _uniswapV3Direct(_tokenIn, _tokenOut, _amount, _minReceived, info);
-		if (route == Route.UniswapV3Path) return _uniswapV3Path(_amount, _minReceived, info);
-		if (route == Route.SushiSwap) return _sushiswap(_amount, _minReceived, info);
+		if (route == Route.UniswapV2) {
+			received = _uniswapV2(_amount, _minReceived, info);
+		} else if (route == Route.UniswapV3Direct) {
+			received = _uniswapV3Direct(_tokenIn, _tokenOut, _amount, _minReceived, info);
+		} else if (route == Route.UniswapV3Path) {
+			received = _uniswapV3Path(_amount, _minReceived, info);
+		} else if (route == Route.SushiSwap) {
+			received = _sushiswap(_amount, _minReceived, info);
+		} else if (route == Route.BalancerBatch) {
+			received = _balancerBatch(_amount, _minReceived, info);
+		} else revert UnsupportedRoute(_tokenIn, _tokenOut);
 
-		revert UnsupportedRoute(_tokenIn, _tokenOut);
+		// return unswapped amount to sender
+		uint256 balance = tokenIn.balanceOf(address(this));
+		if (balance > 0) tokenIn.safeTransfer(msg.sender, balance);
 	}
 
 	/*///////////////////////////////////////////
 	/      Restricted Functions: onlyOwner      /
 	///////////////////////////////////////////*/
 
-	function setRoute(
-		address _tokenIn,
-		address _tokenOut,
-		RouteInfo memory _routeInfo
-	) external onlyOwner {
+	function setRoute(address _tokenIn, address _tokenOut, RouteInfo memory _routeInfo) external onlyOwner {
 		_setRoute(_tokenIn, _tokenOut, _routeInfo);
 	}
 
@@ -172,11 +190,7 @@ contract Swap is Ownable {
 	/      Internal Functions      /
 	//////////////////////////////*/
 
-	function _setRoute(
-		address _tokenIn,
-		address _tokenOut,
-		RouteInfo memory _routeInfo
-	) internal {
+	function _setRoute(address _tokenIn, address _tokenOut, RouteInfo memory _routeInfo) internal {
 		Route route = _routeInfo.route;
 		bytes memory info = _routeInfo.info;
 
@@ -187,10 +201,8 @@ contract Swap is Ownable {
 			if (path[path.length - 1] != _tokenOut) revert InvalidRouteInfo();
 		}
 
-		if (route == Route.UniswapV3Direct) {
-			// just check that this doesn't throw an error
-			abi.decode(info, (uint24));
-		}
+		// just check that this doesn't throw an error
+		if (route == Route.UniswapV3Direct) abi.decode(info, (uint24));
 
 		if (route == Route.UniswapV3Path) {
 			bytes memory path = info;
@@ -205,7 +217,10 @@ contract Swap is Ownable {
 			if (tokenOut != _tokenOut) revert InvalidRouteInfo();
 		}
 
-		address router = route == Route.SushiSwap ? address(sushiswap) : address(uniswap);
+		address router = route == Route.SushiSwap ? address(sushiswap) : route == Route.BalancerBatch
+			? address(balancer)
+			: address(uniswap);
+
 		ERC20(_tokenIn).safeApprove(router, 0);
 		ERC20(_tokenIn).safeApprove(router, type(uint256).max);
 
@@ -213,21 +228,13 @@ contract Swap is Ownable {
 		emit RouteSet(_tokenIn, _tokenOut, _routeInfo);
 	}
 
-	function _uniswapV2(
-		uint256 _amount,
-		uint256 _minReceived,
-		bytes memory _path
-	) internal returns (uint256) {
+	function _uniswapV2(uint256 _amount, uint256 _minReceived, bytes memory _path) internal returns (uint256) {
 		address[] memory path = abi.decode(_path, (address[]));
 
 		return uniswap.swapExactTokensForTokens(_amount, _minReceived, path, msg.sender);
 	}
 
-	function _sushiswap(
-		uint256 _amount,
-		uint256 _minReceived,
-		bytes memory _path
-	) internal returns (uint256) {
+	function _sushiswap(uint256 _amount, uint256 _minReceived, bytes memory _path) internal returns (uint256) {
 		address[] memory path = abi.decode(_path, (address[]));
 
 		uint256[] memory received = sushiswap.swapExactTokensForTokens(
@@ -246,9 +253,9 @@ contract Swap is Ownable {
 		address _tokenOut,
 		uint256 _amount,
 		uint256 _minReceived,
-		bytes memory info
+		bytes memory _info
 	) internal returns (uint256) {
-		uint24 fee = abi.decode(info, (uint24));
+		uint24 fee = abi.decode(_info, (uint24));
 
 		return
 			uniswap.exactInputSingle(
@@ -264,19 +271,45 @@ contract Swap is Ownable {
 			);
 	}
 
-	function _uniswapV3Path(
-		uint256 _amount,
-		uint256 _minReceived,
-		bytes memory path
-	) internal returns (uint256) {
+	function _uniswapV3Path(uint256 _amount, uint256 _minReceived, bytes memory _path) internal returns (uint256) {
 		return
 			uniswap.exactInput(
 				ISwapRouter02.ExactInputParams({
-					path: path,
+					path: _path,
 					recipient: msg.sender,
 					amountIn: _amount,
 					amountOutMinimum: _minReceived
 				})
 			);
+	}
+
+	function _balancerBatch(uint256 _amount, uint256 _minReceived, bytes memory _info) internal returns (uint256) {
+		(IVault.BatchSwapStep[] memory steps, IAsset[] memory assets) = abi.decode(
+			_info,
+			(IVault.BatchSwapStep[], IAsset[])
+		);
+
+		steps[0].amount = _amount;
+
+		int256[] memory limits = new int256[](assets.length);
+
+		limits[0] = int256(_amount);
+		limits[limits.length - 1] = int256(_minReceived);
+
+		int256[] memory received = balancer.batchSwap(
+			IVault.SwapKind.GIVEN_IN,
+			steps,
+			assets,
+			IVault.FundManagement({
+				sender: address(this),
+				fromInternalBalance: false,
+				recipient: payable(address(msg.sender)),
+				toInternalBalance: false
+			}),
+			limits,
+			block.timestamp + 30 minutes
+		);
+
+		return uint256(received[received.length - 1]);
 	}
 }

--- a/src/Swap.sol
+++ b/src/Swap.sol
@@ -146,12 +146,11 @@ contract Swap is Ownable {
 		uint256 _minReceived
 	) external returns (uint256 received) {
 		RouteInfo memory routeInfo = routes[_tokenIn][_tokenOut];
-		Route route = routeInfo.route;
 
 		ERC20 tokenIn = ERC20(_tokenIn);
-
 		tokenIn.safeTransferFrom(msg.sender, address(this), _amount);
 
+		Route route = routeInfo.route;
 		bytes memory info = routeInfo.info;
 
 		if (route == Route.UniswapV2) {

--- a/src/Swap.sol
+++ b/src/Swap.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.9;
 
-import 'forge-std/console.sol';
-
 import 'solmate/tokens/ERC20.sol';
 import 'solmate/utils/SafeTransferLib.sol';
 import './external/uniswap/ISwapRouter02.sol';
@@ -177,7 +175,11 @@ contract Swap is Ownable {
 	/      Restricted Functions: onlyOwner      /
 	///////////////////////////////////////////*/
 
-	function setRoute(address _tokenIn, address _tokenOut, RouteInfo memory _routeInfo) external onlyOwner {
+	function setRoute(
+		address _tokenIn,
+		address _tokenOut,
+		RouteInfo memory _routeInfo
+	) external onlyOwner {
 		_setRoute(_tokenIn, _tokenOut, _routeInfo);
 	}
 
@@ -190,7 +192,11 @@ contract Swap is Ownable {
 	/      Internal Functions      /
 	//////////////////////////////*/
 
-	function _setRoute(address _tokenIn, address _tokenOut, RouteInfo memory _routeInfo) internal {
+	function _setRoute(
+		address _tokenIn,
+		address _tokenOut,
+		RouteInfo memory _routeInfo
+	) internal {
 		Route route = _routeInfo.route;
 		bytes memory info = _routeInfo.info;
 
@@ -228,13 +234,21 @@ contract Swap is Ownable {
 		emit RouteSet(_tokenIn, _tokenOut, _routeInfo);
 	}
 
-	function _uniswapV2(uint256 _amount, uint256 _minReceived, bytes memory _path) internal returns (uint256) {
+	function _uniswapV2(
+		uint256 _amount,
+		uint256 _minReceived,
+		bytes memory _path
+	) internal returns (uint256) {
 		address[] memory path = abi.decode(_path, (address[]));
 
 		return uniswap.swapExactTokensForTokens(_amount, _minReceived, path, msg.sender);
 	}
 
-	function _sushiswap(uint256 _amount, uint256 _minReceived, bytes memory _path) internal returns (uint256) {
+	function _sushiswap(
+		uint256 _amount,
+		uint256 _minReceived,
+		bytes memory _path
+	) internal returns (uint256) {
 		address[] memory path = abi.decode(_path, (address[]));
 
 		uint256[] memory received = sushiswap.swapExactTokensForTokens(
@@ -271,7 +285,11 @@ contract Swap is Ownable {
 			);
 	}
 
-	function _uniswapV3Path(uint256 _amount, uint256 _minReceived, bytes memory _path) internal returns (uint256) {
+	function _uniswapV3Path(
+		uint256 _amount,
+		uint256 _minReceived,
+		bytes memory _path
+	) internal returns (uint256) {
 		return
 			uniswap.exactInput(
 				ISwapRouter02.ExactInputParams({
@@ -283,7 +301,11 @@ contract Swap is Ownable {
 			);
 	}
 
-	function _balancerBatch(uint256 _amount, uint256 _minReceived, bytes memory _info) internal returns (uint256) {
+	function _balancerBatch(
+		uint256 _amount,
+		uint256 _minReceived,
+		bytes memory _info
+	) internal returns (uint256) {
 		(IVault.BatchSwapStep[] memory steps, IAsset[] memory assets) = abi.decode(
 			_info,
 			(IVault.BatchSwapStep[], IAsset[])

--- a/src/external/balancer/IVault.sol
+++ b/src/external/balancer/IVault.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity 0.8.9;
+
+/// https://etherscan.io/address/0xBA12222222228d8Ba445958a75a0704d566BF2C8#code
+
+interface IAsset {
+
+}
+
+interface IVault {
+	enum SwapKind {
+		GIVEN_IN,
+		GIVEN_OUT
+	}
+
+	/**
+	 * @dev Data for each individual swap executed by `batchSwap`. The asset in and out fields are indexes into the
+	 * `assets` array passed to that function, and ETH assets are converted to WETH.
+	 *
+	 * If `amount` is zero, the multihop mechanism is used to determine the actual amount based on the amount in/out
+	 * from the previous swap, depending on the swap kind.
+	 *
+	 * The `userData` field is ignored by the Vault, but forwarded to the Pool in the `onSwap` hook, and may be
+	 * used to extend swap behavior.
+	 */
+	struct BatchSwapStep {
+		bytes32 poolId;
+		uint256 assetInIndex;
+		uint256 assetOutIndex;
+		uint256 amount;
+		bytes userData;
+	}
+
+	/**
+	 * @dev All tokens in a swap are either sent from the `sender` account to the Vault, or from the Vault to the
+	 * `recipient` account.
+	 *
+	 * If the caller is not `sender`, it must be an authorized relayer for them.
+	 *
+	 * If `fromInternalBalance` is true, the `sender`'s Internal Balance will be preferred, performing an ERC20
+	 * transfer for the difference between the requested amount and the User's Internal Balance (if any). The `sender`
+	 * must have allowed the Vault to use their tokens via `IERC20.approve()`. This matches the behavior of
+	 * `joinPool`.
+	 *
+	 * If `toInternalBalance` is true, tokens will be deposited to `recipient`'s internal balance instead of
+	 * transferred. This matches the behavior of `exitPool`.
+	 *
+	 * Note that ETH cannot be deposited to or withdrawn from Internal Balance: attempting to do so will trigger a
+	 * revert.
+	 */
+	struct FundManagement {
+		address sender;
+		bool fromInternalBalance;
+		address payable recipient;
+		bool toInternalBalance;
+	}
+
+	/**
+	 * @dev Performs a series of swaps with one or multiple Pools. In each individual swap, the caller determines either
+	 * the amount of tokens sent to or received from the Pool, depending on the `kind` value.
+	 *
+	 * Returns an array with the net Vault asset balance deltas. Positive amounts represent tokens (or ETH) sent to the
+	 * Vault, and negative amounts represent tokens (or ETH) sent by the Vault. Each delta corresponds to the asset at
+	 * the same index in the `assets` array.
+	 *
+	 * Swaps are executed sequentially, in the order specified by the `swaps` array. Each array element describes a
+	 * Pool, the token to be sent to this Pool, the token to receive from it, and an amount that is either `amountIn` or
+	 * `amountOut` depending on the swap kind.
+	 *
+	 * Multihop swaps can be executed by passing an `amount` value of zero for a swap. This will cause the amount in/out
+	 * of the previous swap to be used as the amount in for the current one. In a 'given in' swap, 'tokenIn' must equal
+	 * the previous swap's `tokenOut`. For a 'given out' swap, `tokenOut` must equal the previous swap's `tokenIn`.
+	 *
+	 * The `assets` array contains the addresses of all assets involved in the swaps. These are either token addresses,
+	 * or the IAsset sentinel value for ETH (the zero address). Each entry in the `swaps` array specifies tokens in and
+	 * out by referencing an index in `assets`. Note that Pools never interact with ETH directly: it will be wrapped to
+	 * or unwrapped from WETH by the Vault.
+	 *
+	 * Internal Balance usage, sender, and recipient are determined by the `funds` struct. The `limits` array specifies
+	 * the minimum or maximum amount of each token the vault is allowed to transfer.
+	 *
+	 * `batchSwap` can be used to make a single swap, like `swap` does, but doing so requires more gas than the
+	 * equivalent `swap` call.
+	 *
+	 * Emits `Swap` events.
+	 */
+	function batchSwap(
+		SwapKind kind,
+		BatchSwapStep[] memory swaps,
+		IAsset[] memory assets,
+		FundManagement memory funds,
+		int256[] memory limits,
+		uint256 deadline
+	) external payable returns (int256[] memory);
+}

--- a/test/integration/Swap.t.sol
+++ b/test/integration/Swap.t.sol
@@ -6,11 +6,11 @@ import 'src/Swap.sol';
 
 contract SwapTest is Test {
 	address internal constant CVX = 0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B;
-	address internal constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+	address internal constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
 
 	function testDeploysCorrectly() public {
 		Swap swap = new Swap();
-		Swap.RouteInfo memory info = swap.getRoute(CVX, USDC);
-		assert(info.route == Swap.Route.UniswapV3Path);
+		Swap.RouteInfo memory info = swap.getRoute(CVX, WETH);
+		assert(info.route == Swap.Route.UniswapV3Direct);
 	}
 }

--- a/test/integration/TreasuryConvexTricrypto.t.sol
+++ b/test/integration/TreasuryConvexTricrypto.t.sol
@@ -40,12 +40,6 @@ contract TreasuryConvexTricryptoTest is TestHelpers {
 
 		swap = new Swap();
 
-		swap.setRoute(
-			address(USDC),
-			address(USDT),
-			Swap.RouteInfo({route: Swap.Route.UniswapV3Direct, info: abi.encode(uint24(100))})
-		);
-
 		wethTreasury = new TreasuryConvexTricrypto(wethStaking, address(0), address(this), new address[](0), swap, 2);
 		usdcTreasury = new TreasuryConvexTricrypto(usdcStaking, address(0), address(this), new address[](0), swap, 0);
 

--- a/test/integration/UsdcStrategyStargate.t.sol
+++ b/test/integration/UsdcStrategyStargate.t.sol
@@ -27,12 +27,6 @@ contract UsdcStrategyStargateTest is TestHelpers {
 		vault = new Vault(USDC, 0, 0, address(0), address(this), new address[](0));
 		swap = new Swap();
 
-		swap.setRoute(
-			address(STG),
-			address(USDC),
-			Swap.RouteInfo({route: Swap.Route.UniswapV3Direct, info: abi.encode(uint24(3_000))})
-		);
-
 		strategy = new UsdcStrategyStargate(vault, treasury, address(0), address(this), new address[](0), swap);
 		vault.addStrategy(strategy, 100);
 	}
@@ -41,11 +35,7 @@ contract UsdcStrategyStargateTest is TestHelpers {
 	/      Helpers      /
 	///////////////////*/
 
-	function depositUsdc(
-		address from,
-		uint256 amount,
-		address receiver
-	) public {
+	function depositUsdc(address from, uint256 amount, address receiver) public {
 		vm.prank(usdcWhale);
 		USDC.transfer(from, amount);
 		vm.startPrank(from);

--- a/test/unit/Vault.t.sol
+++ b/test/unit/Vault.t.sol
@@ -25,11 +25,7 @@ contract VaultTest is Test {
 	/      Helpers      /
 	///////////////////*/
 
-	function deposit(
-		address from,
-		uint256 amount,
-		address receiver
-	) internal {
+	function deposit(address from, uint256 amount, address receiver) internal {
 		token.mint(from, amount);
 		vm.startPrank(from);
 		token.approve(address(vault), type(uint256).max);
@@ -109,12 +105,12 @@ contract VaultTest is Test {
 		assertEq(vault.freeAssets(), 0);
 		assertEq(vault.totalAssets(), amount);
 
-		vm.warp(block.timestamp + 3 hours);
+		vm.warp(block.timestamp + 12 hours);
 
 		assertEq(vault.lockedProfit(), amount.mulDivUp(1, 2));
 		assertEq(vault.freeAssets(), amount.mulDivDown(1, 2));
 
-		vm.warp(block.timestamp + 6 hours);
+		vm.warp(block.timestamp + 24 hours);
 
 		assertEq(vault.lockedProfit(), 0);
 		assertEq(vault.freeAssets(), amount);


### PR DESCRIPTION
For STG -> USDC and can support other tokens with liquidity on balancer ATM

not final due to STG [migrating to a new token address](https://snapshot.org/#/stgdao.eth/proposal/0x26a68e276ab63195580c5100423c5db7177c9a0f15c74e5d8393812332b28836) which means new liquidity pools

this works on currently STG address. might deploy and use this for one last harvest of STG -> USDC on March 13/14th before the migration depending on whether its profitable to do so at current gas costs

## Others

also move all sushiswap routes to uniswap v3. sushiswap liquidity seems to be dying
